### PR TITLE
update for MC 1.20+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,15 @@
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <relocations>
+                        <relocation>
+                            <pattern>org.bstats</pattern>
+                            <!-- Replace this with your package! -->
+                            <shadedPattern>me.sashie.skriptyaml.bstats</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
             </plugin>
         </plugins>
         <resources>
@@ -79,6 +88,13 @@
             <groupId>com.github.SkriptLang</groupId>
             <artifactId>Skript</artifactId>
             <version>2.6.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bukkit</artifactId>
+            <version>3.0.2</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/me/sashie/skriptyaml/SkriptYaml.java
+++ b/src/main/java/me/sashie/skriptyaml/SkriptYaml.java
@@ -107,11 +107,9 @@ public class SkriptYaml extends JavaPlugin {
 
 	@Override
 	public void onEnable() {
-		String initServerVer = Bukkit.getBukkitVersion().split("\\.")[1].split("\\.")[0];
-		serverVersion = Integer.parseInt(initServerVer);
-
 		Plugin skript = Bukkit.getServer().getPluginManager().getPlugin("Skript");
 		if (skript != null) {
+			serverVersion = Skript.getMinecraftVersion().getMinor();
 			if (Skript.isAcceptRegistrations()) {
 				try {
 					SkriptAddon addonInstance = Skript.registerAddon(this);

--- a/src/main/java/me/sashie/skriptyaml/SkriptYaml.java
+++ b/src/main/java/me/sashie/skriptyaml/SkriptYaml.java
@@ -13,8 +13,8 @@ import me.sashie.skriptyaml.utils.versions.V2_6;
 import me.sashie.skriptyaml.utils.yaml.SkriptYamlConstructor;
 import me.sashie.skriptyaml.utils.yaml.SkriptYamlRepresenter;
 import me.sashie.skriptyaml.utils.yaml.YAMLProcessor;
-import shaded.org.bstats.bukkit.Metrics;
-import shaded.org.bstats.charts.DrilldownPie;
+import org.bstats.bukkit.Metrics;
+import org.bstats.charts.DrilldownPie;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -107,12 +107,8 @@ public class SkriptYaml extends JavaPlugin {
 
 	@Override
 	public void onEnable() {
-		String initServerVer = Bukkit.getServer().getClass().getPackage().getName().substring(23);
-		serverVersion = Integer.parseInt(Character.toString(initServerVer.charAt(3)));
-		if (serverVersion == 1 && Integer.parseInt(Character.toString(initServerVer.charAt(4))) >= 0) {
-			serverVersion = Integer.parseInt(Integer.parseInt(Character.toString(initServerVer.charAt(3))) + ""
-					+ Integer.parseInt(Character.toString(initServerVer.charAt(4))));
-		}
+		String initServerVer = Bukkit.getBukkitVersion().split("\\.")[1].split("\\.")[0];
+		serverVersion = Integer.parseInt(initServerVer);
 
 		Plugin skript = Bukkit.getServer().getPluginManager().getPlugin("Skript");
 		if (skript != null) {

--- a/src/main/java/me/sashie/skriptyaml/utils/yaml/SkriptYamlConstructor.java
+++ b/src/main/java/me/sashie/skriptyaml/utils/yaml/SkriptYamlConstructor.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.util.Vector;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.AbstractConstruct;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.error.YAMLException;
@@ -28,6 +29,7 @@ import java.util.regex.Pattern;
 public class SkriptYamlConstructor extends SafeConstructor {
 
 	public SkriptYamlConstructor() {
+		super(new LoaderOptions());
 		this.yamlConstructors.put(new Tag("!skriptclass"), new ConstructSkriptClass());
 
 		this.yamlConstructors.put(new Tag("!vector"), new ConstructVector());

--- a/src/main/java/me/sashie/skriptyaml/utils/yaml/SkriptYamlRepresenter.java
+++ b/src/main/java/me/sashie/skriptyaml/utils/yaml/SkriptYamlRepresenter.java
@@ -45,6 +45,7 @@ public class SkriptYamlRepresenter extends Representer {
 	private static List<String> representedClasses = new ArrayList<>();
 
 	public SkriptYamlRepresenter() {
+		super(new DumperOptions());
 		this.nullRepresenter = new Represent() {
 			@Override
 			public Node representData(Object o) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: skript-yaml
 author: Sashie
 description: The proper way to do yaml in skript
-api-version: 1.19
+api-version: 1.16
 version: '${project.version}'
 main: me.sashie.skriptyaml.SkriptYaml
 depend: [Skript]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,6 @@ name: skript-yaml
 author: Sashie
 description: The proper way to do yaml in skript
 api-version: 1.19
-version: 1.4.1
+version: '${project.version}'
 main: me.sashie.skriptyaml.SkriptYaml
 depend: [Skript]


### PR DESCRIPTION
This PR aims to get Skript-Yaml working on MC 1.20+

### Notable Changes:
- SkriptYamlConstructor and SkriptYamlRepresenter include super constructor with params (old one was deprecated and finally removed in SnakeYaml 2.0 - Bukkit updated to SnakeYaml 2.0 in 1.20)
- I added bStats as a dependency and shade it. Im not sure where bStats was coming from before, but it was giving me errors
- Updated plugin.yml so you don't have to manually change the version each time, it'll just grab it from your pom
- Updated plugin.yml to use api-version 1.16 (tested all the way back to 1.16 and it worked, 1.15 caused an error due to too old of a SnakeYaml version)
- Fixed the serverVersion thing in onEnable(). It was returning "2" instead of "20" (for 1.20) thus not running the correct methods in the earlier mentioned classes (twas running the old methods via reflection, thus causing errors).

### Testing:
- Light testing on both Paper 1.19.4 and 1.20.1, both work fine

### Issues:
- Reference #46 and #44